### PR TITLE
Fix search from all pages

### DIFF
--- a/src/components/Header/SearchBar.js
+++ b/src/components/Header/SearchBar.js
@@ -28,14 +28,13 @@ const SearchForm = ({ values, handleChange, handleSubmit }) => (
 const withForm = withFormik({
   mapPropsToValues: props => ({ query: props.query }),
   handleSubmit: (values, { props }) => {
-  handleSubmit: (values, props) => {
     setUrlState(
       {
         query: values.query,
       },
       {
         flushSearch: true,
-        location: { pathname: '/', search: '' },
+        location: { pathname: '/' },
         history: props.history,
       },
     );

--- a/src/components/Header/SearchBar.js
+++ b/src/components/Header/SearchBar.js
@@ -27,14 +27,14 @@ const SearchForm = ({ values, handleChange, handleSubmit }) => (
 
 const withForm = withFormik({
   mapPropsToValues: props => ({ query: props.query }),
-  handleSubmit: (values, props) => {
+  handleSubmit: (values, { props }) => {
     setUrlState(
       {
         query: values.query,
       },
       {
         flushSearch: true,
-        location: props.location,
+        location: { pathname: '/', search: '' },
         history: props.history,
       },
     );


### PR DESCRIPTION
Closes #32 

You can now search without a page refresh, and it works from all locations, including cart and order page.