### PR TITLE
Fix product list layout when few items

### DIFF
--- a/src/components/ProductList/ProductList.css
+++ b/src/components/ProductList/ProductList.css
@@ -14,10 +14,11 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 .productlist-item {
+  margin-left: 24px;
   width: 160px;
   height: 240px;
   display: flex;


### PR DESCRIPTION
When only two items in the product layout, the `space-between` attribute in flexbox made the two items go to each side. Making them start on the left, and giving them a margin made it look better.

Closes #31 