### PR TITLE
Add version to cache persistance

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import DocumentTitle from 'react-document-title';
 import { ApolloClient } from 'apollo-client';
 import { ApolloProvider } from 'react-apollo';
 import { ApolloLink } from 'apollo-link';
-import { persistCache } from 'apollo-cache-persist';
 
 import Layout from './components/Layout';
 import Main from './pages/Main';
@@ -13,12 +12,10 @@ import cache from './cache/cache';
 import stateLink from './cache/stateLink';
 import authLink from './cache/authLink';
 import httpLink from './cache/httpLink';
+import persistCache from './cache/persist';
 import './App.css';
 
-persistCache({
-  cache,
-  storage: window.localStorage,
-});
+persistCache(cache);
 
 const client = new ApolloClient({
   link: ApolloLink.from([stateLink, authLink.concat(httpLink)]),

--- a/src/cache/persist.js
+++ b/src/cache/persist.js
@@ -1,0 +1,20 @@
+import { CachePersistor } from 'apollo-cache-persist';
+
+const SCHEMA_VERSION = '1'; // Must be a string.
+const SCHEMA_VERSION_KEY = 'apollo-schema-version';
+
+export default function persistCache(cache) {
+  const persistor = new CachePersistor({
+    cache,
+    storage: window.localStorage,
+  });
+
+  const currentVersion = window.localStorage.getItem(SCHEMA_VERSION_KEY);
+
+  if (currentVersion === SCHEMA_VERSION) {
+    persistor.restore();
+  } else {
+    persistor.purge();
+    window.localStorage.setItem(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
+  }
+}


### PR DESCRIPTION
If the schema changes, the cache persistence will get problems. In order to purge the cache when the schema changes, you can simply update the version tag in the frontend code.