### PR TITLE
Fix typo in GraphQL query

### DIFF
--- a/src/mutations/signup.js
+++ b/src/mutations/signup.js
@@ -7,7 +7,7 @@ export const query = gql`
     $lastName: String!
     $username: String!
     $password: String!
-    $mail: String!
+    $email: String!
   ) {
     createAccount(
       firstName: $firstName


### PR DESCRIPTION
This should fix the issue with not being able to create accounts.